### PR TITLE
Added folder for KiCad 3D models

### DIFF
--- a/kicad-3dmodels/.gitignore
+++ b/kicad-3dmodels/.gitignore
@@ -1,0 +1,1 @@
+tp4056-module.wrl


### PR DESCRIPTION
I initially added a 3D model for the TP4056 module, but it was not created by me, so I omitted it due to copyright reasons. It can be downloaded from:

https://kicadrookie.blogspot.com/2022/01/tp4056-module-kicad-3d-asset.html

If you choose to download it, the scaling factor for all three axes when importing into KiCad seems to be 0.393.